### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/porter_construction_grown_paint.yml
+++ b/.github/workflows/porter_construction_grown_paint.yml
@@ -1,0 +1,43 @@
+"on":
+  push:
+    branches:
+    - master
+name: Deploy to Porter
+jobs:
+  porter-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.3.4
+    - name: Download Porter
+      id: download_porter
+      run: |2
+
+        name=$(curl -s https://api.github.com/repos/porter-dev/porter/releases/latest | grep "browser_download_url.*/porter_.*_Linux_x86_64\.zip" | cut -d ":" -f 2,3 | tr -d \")
+        name=$(basename $name)
+        curl -L https://github.com/porter-dev/porter/releases/latest/download/$name --output $name
+        unzip -a $name
+        rm $name
+        chmod +x ./porter
+        sudo mv ./porter /usr/local/bin/porter
+    - name: Configure Porter
+      id: configure_porter
+      run: |2
+
+        sudo porter auth login --token ${{secrets.PORTER_TOKEN_487}}
+        sudo porter docker configure
+    - name: Docker build, push
+      id: docker_build_push
+      run: |2
+
+        export $(echo "${{secrets.ENV_CONSTRUCTION_GROWN_PAINT}}" | xargs)
+        sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
+        sudo apt-get update
+        sudo apt-get install pack-cli
+        sudo pack build 524263944541.dkr.ecr.us-east-1.amazonaws.com/construction-grown-paint-default:$(git rev-parse --short HEAD) --path src --builder heroku/buildpacks:18
+        sudo docker push 524263944541.dkr.ecr.us-east-1.amazonaws.com/construction-grown-paint-default:$(git rev-parse --short HEAD)
+    - name: Deploy on Porter
+      id: deploy_porter
+      run: |2
+
+        curl -X POST "https://dashboard.getporter.dev/api/webhooks/deploy/${{secrets.WEBHOOK_CONSTRUCTION_GROWN_PAINT}}?commit=$(git rev-parse --short HEAD)&repository=524263944541.dkr.ecr.us-east-1.amazonaws.com/construction-grown-paint-default"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
         id: vars
         run: echo ::set-output name=GITHUB_TAG::${GITHUB_REF:10} # Remove /refs/head/
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: reacherhq/backend
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore